### PR TITLE
feat: show equipment status on list page

### DIFF
--- a/equipmentdb/models.py
+++ b/equipmentdb/models.py
@@ -60,6 +60,16 @@ class Equipment(UbucModel):
         return FaultStatus.NO_FAULT
 
     @property
+    def test_status_formatted(self):
+        test_statuses = [(0, "Unknown")]
+        if -1 not in self.test_status.keys():
+            test_statuses = [
+                (ttid, f"{TestType.objects.get(pk=ttid).name} - {t_status.label}")
+                for ttid, t_status in self.test_status.items()
+            ]
+        return test_statuses
+
+    @property
     def test_status(self) -> Dict[int, TestStatus]:
         if (
             not self.tests.exists()

--- a/equipmentdb/templates/equipmentdb/equipment_list.html
+++ b/equipmentdb/templates/equipmentdb/equipment_list.html
@@ -1,12 +1,30 @@
 {% extends "equipmentdb/base.html" %}
 {% block content %}
 <h2>Equipment Items</h2>
-<ul>
-{% for equipment in object_list %}
-    <li>{{ equipment }} <a href="./equipment/{{equipment.id}}">Edit</a> <a href="./equipment/{{equipment.id}}/delete">Delete</a> </li>
-{% empty %}
+<table class="table">
+    <thead>
+    <th scope="col">Type</th>
+    <th scope="col">ID</th>
+    <th scope="col">Fault Status</th>
+    <th scope="col">Service Status</th>
+    <th scope="col">Test Status</th>
+    <th scope="col"></th>
+    <th scope="col"></th>
+    </thead>
+    {% for equipment in object_list %}
+    <tr>
+        <td>{{equipment.equipment_type}}</td>
+        <td>{{equipment.ubuc_id}}</td>
+        <td>{{equipment.fault_status.label}}</td>
+        <td>{{equipment.service_status.label}}</td>
+        <td>{% for teststatus in equipment.test_status_formatted%} {{teststatus.1}}<br/>{% endfor %}</td>
+        <td><a href="./equipment/{{equipment.id}}">Edit</a></td>
+        <td><a href="./equipment/{{equipment.id}}/delete">Delete</a></td>
+    </tr>
+    {% empty %}
     <li>No equipment items yet.</li>
-{% endfor %}
-</ul>
-<a href="./equipment/add">Add new equipment item</a>
-{% endblock content %}
+    {% endfor %}
+    </ul>
+</table>
+    <a href="./equipment/add">Add new equipment item</a>
+    {% endblock content %}

--- a/equipmentdb/views.py
+++ b/equipmentdb/views.py
@@ -67,14 +67,8 @@ class EquipmentUpdateView(UbucBaseUpdateView):
             initial=equipment_item.service_time_remaining, disabled=True, required=False
         )
 
-        test_statuses = [(0, "Unknown")]
-        if -1 not in equipment_item.test_status.keys():
-            test_statuses = [
-                (ttid, f"{TestType.objects.get(pk=ttid).name} - {t_status.label}")
-                for ttid, t_status in equipment_item.test_status.items()
-            ]
         form.fields["test_status"] = forms.MultipleChoiceField(
-            disabled=True, required=False, choices=test_statuses
+            disabled=True, required=False, choices=equipment_item.test_status_formatted
         )
 
         if "disposed_on" not in form.initial or form.initial["disposed_on"] == None:


### PR DESCRIPTION
- move test status formatting to equipment model
- use table rather than list for equipment, include statuses
- change equipment edit view to use model-based formatted test state